### PR TITLE
output.time_reference parameter loading fix

### DIFF
--- a/src/config_store.cpp
+++ b/src/config_store.cpp
@@ -387,7 +387,7 @@ void ConfigStore::loadFromRosNodeHandle(const rclcpp::Node& ref_node_handle)
   loadOdometerParameters(ref_node_handle);
   loadOutputFrameParameters(ref_node_handle);
 
-  loadOutputTimeReference(ref_node_handle, "output/time_reference");
+  loadOutputTimeReference(ref_node_handle, "output.time_reference");
 
   loadOutputConfiguration(ref_node_handle, "output.log_status", SBG_ECOM_CLASS_LOG_ECOM_0, SBG_ECOM_LOG_STATUS);
   loadOutputConfiguration(ref_node_handle, "output.log_imu_data", SBG_ECOM_CLASS_LOG_ECOM_0, SBG_ECOM_LOG_IMU_DATA);


### PR DESCRIPTION
Typo in parameter path fixed (issue #10) 