### PR TITLE
Remove boost dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(tf2_ros REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(Boost REQUIRED)
 
 ################################################
 ## Declare ROS messages, services and actions ##

--- a/package.xml
+++ b/package.xml
@@ -50,7 +50,6 @@
   <depend>tf2_ros</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>boost</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/src/sbg_device.cpp
+++ b/src/sbg_device.cpp
@@ -6,12 +6,6 @@
 #include <fstream>
 #include <ctime>
 
-// Boost headers
-#include <boost/lexical_cast.hpp>
-#include <boost/regex.hpp>
-#include <boost/thread/xtime.hpp>
-#include <boost/date_time/local_time/local_time.hpp>
-
 // SbgECom headers
 #include <version/sbgVersion.h>
 
@@ -19,14 +13,12 @@ using namespace std;
 using sbg::SbgDevice;
 
 // From ros_com/recorder
-std::string timeToStr() //rclcpp::WallTimer<std::function<void()>> ros_t) //TODO: FIXME
+std::string timeToStr()
 {
-    //(void)ros_t;
     std::stringstream msg;
-    const boost::posix_time::ptime now = boost::posix_time::second_clock::local_time();
-    boost::posix_time::time_facet *const f = new boost::posix_time::time_facet("%Y-%m-%d-%H-%M-%S");
-    msg.imbue(std::locale(msg.getloc(),f));
-    msg << now;
+    auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    auto tm = *std::localtime(&now);
+    msg << std::put_time(&tm, "%Y-%m-%d-%H-%M-%S");
     return msg.str();
 }
 
@@ -442,7 +434,7 @@ void SbgDevice::exportMagCalibrationResults(void) const
   mag_results_stream << m_magCalibResults.matrix[3] << "\t" << m_magCalibResults.matrix[4] << "\t" << m_magCalibResults.matrix[5] << endl;
   mag_results_stream << m_magCalibResults.matrix[6] << "\t" << m_magCalibResults.matrix[7] << "\t" << m_magCalibResults.matrix[8] << endl;
 
-  output_filename = "mag_calib_" + timeToStr()/*(nullptrrclcpp::WallTimer::now())*/ + ".txt";
+  output_filename = "mag_calib_" + timeToStr() + ".txt";
   ofstream output_file(output_filename);
   output_file << mag_results_stream.str();
   output_file.close();


### PR DESCRIPTION
Hi,

Currently the boost library is only used in de function "timeToStr" in the sbg_device.cpp
As this is also possible without boost, i would like to remove the boost dependency.

I tested the output of the code:
OLD: 2023-11-29-08-03-14
NEW: 2023-11-29-08-03-14


