### PR TITLE
FEAT: Improved rollover handling to avoid issues with late sensor messages

### DIFF
--- a/src/message_wrapper.cpp
+++ b/src/message_wrapper.cpp
@@ -79,27 +79,23 @@ const rclcpp::Time MessageWrapper::convertInsTimeToUnix(uint32_t device_timestam
 {
   //
   // Convert the UTC time to epoch from the last received message.
-  // Add the SBG timestamp difference (timestamp is in microsecond).
+  // Add the SBG timestamp difference (timestamp is in microsecond since device boot).
   //
   rclcpp::Time utc_to_epoch;
   uint64_t  nanoseconds;
 
   utc_to_epoch = convertUtcTimeToUnix(last_sbg_utc_);
 
-  // Handle 32-bit device timestamp rollover.
-  uint32_t timestamp_diff;
-  if (device_timestamp >= last_sbg_utc_.time_stamp)
+  // Convert difference to signed 64-bit
+  int64_t timestamp_diff = static_cast<int64_t>(device_timestamp) - static_cast<int64_t>(last_sbg_utc_.time_stamp);
+  
+  // Handle 32-bit device timestamp rollover if diff is very negative.
+  if (timestamp_diff < -static_cast<int64_t>(UINT32_MAX / 2))
   {
-    // No rollover, straightforward time difference.
-    timestamp_diff = device_timestamp - last_sbg_utc_.time_stamp;
-  }
-  else
-  {
-    // Rollover has occurred: handle the wraparound.
-    timestamp_diff = device_timestamp + (UINT32_MAX - last_sbg_utc_.time_stamp) + 1;
+      timestamp_diff = static_cast<int64_t>(device_timestamp) + (UINT32_MAX - static_cast<uint64_t>(last_sbg_utc_.time_stamp)) + 1;
   }
 
-  nanoseconds  = utc_to_epoch.nanoseconds() + static_cast<uint64_t>(timestamp_diff) * 1000;
+  nanoseconds  = utc_to_epoch.nanoseconds() + timestamp_diff * 1000LL;
 
   utc_to_epoch = rclcpp::Time(nanoseconds);
 


### PR DESCRIPTION
**PR resolves Issue #52**

This pull request refines the logic for converting device timestamps to Unix time, specifically improving how **32-bit timestamp rollover** is handled in the `MessageWrapper::convertInsTimeToUnix` method. The main change is a more robust calculation of the timestamp difference using **signed arithmetic**, which better detects and manages rollover scenarios.

**Issues addressed:**

- The original code calculated `timestamp_diff` as an **unsigned int**, but it can be negative if a measurement arrives before the last UTC timestamp.  
- A negative `timestamp_diff` does **not necessarily indicate a rollover**. In the case of the magnetometer, some measurements were delayed, causing the UTC timestamp to update while the device timestamp was still slightly behind.

**Changes in this PR:**

- Updated the calculation of `timestamp_diff` to use **signed 64-bit arithmetic**, allowing robust detection of 32-bit device timestamp rollover and simplifying the wraparound logic.  
- Clarified comments to indicate that the SBG timestamp is in **microseconds since device boot**.  
- Edge case: this approach will only fail if a sensor message arrives more than ~36 minutes late, which is highly unlikely in normal operation.
