### PR TITLE
Proper integration of imu_short and remove dynamic tf-broadcaster for static transform

### DIFF
--- a/src/message_publisher.cpp
+++ b/src/message_publisher.cpp
@@ -222,7 +222,7 @@ void MessagePublisher::defineRosStandardPublishers(rclcpp::Node& ref_ros_node_ha
     return;
   }
 
-  if (sbg_imu_data_pub_ && sbg_ekf_quat_pub_)
+  if ((sbg_imu_data_pub_ || sbg_imu_short_pub_) && sbg_ekf_quat_pub_)
   {
     imu_pub_ = ref_ros_node_handle.create_publisher<sensor_msgs::msg::Imu>("imu/data", max_messages_);
   }
@@ -231,7 +231,7 @@ void MessagePublisher::defineRosStandardPublishers(rclcpp::Node& ref_ros_node_ha
     RCLCPP_WARN(ref_ros_node_handle.get_logger(), "SBG_DRIVER - [Publisher] SBG Imu and/or Quat output are not configured, the standard IMU can not be defined.");
   }
 
-  if (sbg_imu_data_pub_)
+  if (sbg_imu_data_pub_ || sbg_imu_short_pub_)
   {
     temp_pub_ = ref_ros_node_handle.create_publisher<sensor_msgs::msg::Temperature>("imu/temp", max_messages_);
   }
@@ -253,7 +253,7 @@ void MessagePublisher::defineRosStandardPublishers(rclcpp::Node& ref_ros_node_ha
   // We need either Euler or quat angles, and we must have Nav and IMU data to
   // compute Body and angular velocity.
   //
-  if ((sbg_ekf_euler_pub_ || sbg_ekf_quat_pub_) && sbg_ekf_nav_pub_ && sbg_imu_data_pub_)
+  if ((sbg_ekf_euler_pub_ || sbg_ekf_quat_pub_) && sbg_ekf_nav_pub_ && (sbg_imu_data_pub_ || sbg_imu_short_pub_))
   {
     velocity_pub_ = ref_ros_node_handle.create_publisher<geometry_msgs::msg::TwistStamped>("imu/velocity", max_messages_);
   }
@@ -300,7 +300,7 @@ void MessagePublisher::defineRosStandardPublishers(rclcpp::Node& ref_ros_node_ha
 
   if (odom_enable)
   {
-    if (sbg_imu_data_pub_ && sbg_ekf_nav_pub_ && (sbg_ekf_euler_pub_ || sbg_ekf_quat_pub_))
+    if ((sbg_imu_data_pub_ || sbg_imu_short_pub_) && sbg_ekf_nav_pub_ && (sbg_ekf_euler_pub_ || sbg_ekf_quat_pub_))
     {
       odometry_pub_ = ref_ros_node_handle.create_publisher<nav_msgs::msg::Odometry>("imu/odometry", max_messages_);
     }
@@ -390,26 +390,17 @@ void MessagePublisher::processRosOdoMessage()
     {
       if (sbg_imu_short_pub_)
       {
-        if (sbg_imu_short_message_.time_stamp == sbg_ekf_nav_message_.time_stamp)
+        /*
+        * Odometry message can be generated from quaternion or euler angles.
+        * Quaternion is prefered if they are available.
+        */
+        if (sbg_ekf_quat_pub_)
         {
-          /*
-          * Odometry message can be generated from quaternion or euler angles.
-          * Quaternion is prefered if they are available.
-          */
-          if (sbg_ekf_quat_pub_)
-          {
-            if (sbg_imu_short_message_.time_stamp == sbg_ekf_quat_message_.time_stamp)
-            {
-              odometry_pub_->publish(message_wrapper_.createRosOdoMessage(sbg_imu_short_message_, sbg_ekf_nav_message_, sbg_ekf_quat_message_, sbg_ekf_euler_message_));
-            }
-          }
-          else
-          {
-            if (sbg_imu_short_message_.time_stamp == sbg_ekf_euler_message_.time_stamp)
-            {
-              odometry_pub_->publish(message_wrapper_.createRosOdoMessage(sbg_imu_short_message_, sbg_ekf_nav_message_, sbg_ekf_euler_message_));
-            }
-          }
+          odometry_pub_->publish(message_wrapper_.createRosOdoMessage(sbg_imu_short_message_, sbg_ekf_nav_message_, sbg_ekf_quat_message_, sbg_ekf_euler_message_));
+        }
+        else
+        {
+          odometry_pub_->publish(message_wrapper_.createRosOdoMessage(sbg_imu_short_message_, sbg_ekf_nav_message_, sbg_ekf_euler_message_));
         }
       }
       else if (sbg_imu_data_pub_)

--- a/src/message_publisher.cpp
+++ b/src/message_publisher.cpp
@@ -367,7 +367,8 @@ void MessagePublisher::processRosImuMessage()
 
     if (sbg_imu_short_pub_)
     {
-      if (sbg_ekf_quat_pub_)
+      rclcpp::Duration eps = rclcpp::Duration::from_seconds(1e-8);
+      if ((sbg_ekf_quat_message_ == ekf_quat_message_zero) || ((rclcpp::Time(sbg_imu_short_message_.header.stamp) - rclcpp::Time(sbg_ekf_quat_message_.header.stamp)) < eps))
       {
         imu_pub_->publish(message_wrapper_.createRosImuMessage(sbg_imu_short_message_, sbg_ekf_quat_message_));
       }
@@ -390,17 +391,27 @@ void MessagePublisher::processRosOdoMessage()
     {
       if (sbg_imu_short_pub_)
       {
-        /*
-        * Odometry message can be generated from quaternion or euler angles.
-        * Quaternion is prefered if they are available.
-        */
-        if (sbg_ekf_quat_pub_)
+        rclcpp::Duration eps = rclcpp::Duration::from_seconds(1e-8);
+        if ((rclcpp::Time(sbg_imu_short_message_.header.stamp) - rclcpp::Time(sbg_ekf_nav_message_.header.stamp)) < eps)
         {
-          odometry_pub_->publish(message_wrapper_.createRosOdoMessage(sbg_imu_short_message_, sbg_ekf_nav_message_, sbg_ekf_quat_message_, sbg_ekf_euler_message_));
-        }
-        else
-        {
-          odometry_pub_->publish(message_wrapper_.createRosOdoMessage(sbg_imu_short_message_, sbg_ekf_nav_message_, sbg_ekf_euler_message_));
+          /*
+          * Odometry message can be generated from quaternion or euler angles.
+          * Quaternion is prefered if they are available.
+          */
+          if (sbg_ekf_quat_pub_)
+          {
+            if ((rclcpp::Time(sbg_imu_short_message_.header.stamp) - rclcpp::Time(sbg_ekf_quat_message_.header.stamp)) < eps)
+            {
+              odometry_pub_->publish(message_wrapper_.createRosOdoMessage(sbg_imu_short_message_, sbg_ekf_nav_message_, sbg_ekf_quat_message_, sbg_ekf_euler_message_));
+            }
+          }
+          else
+          {
+            if ((rclcpp::Time(sbg_imu_short_message_.header.stamp) - rclcpp::Time(sbg_ekf_euler_message_.time_stamp)) < eps)
+            {
+              odometry_pub_->publish(message_wrapper_.createRosOdoMessage(sbg_imu_short_message_, sbg_ekf_nav_message_, sbg_ekf_euler_message_));
+            }
+          }
         }
       }
       else if (sbg_imu_data_pub_)

--- a/src/message_publisher.cpp
+++ b/src/message_publisher.cpp
@@ -2,6 +2,15 @@
 
 using sbg::MessagePublisher;
 
+namespace
+{
+bool areStampsClose(const builtin_interfaces::msg::Time &lhs, const builtin_interfaces::msg::Time &rhs, const rclcpp::Duration &tolerance = rclcpp::Duration::from_seconds(25e-4))
+{
+  const auto delta = rclcpp::Time(lhs) - rclcpp::Time(rhs);
+  return (delta > tolerance*-1) && (delta < tolerance);
+}
+}
+
 /*!
  * Class to publish all SBG-ROS messages to the corresponding publishers. 
  */
@@ -367,8 +376,7 @@ void MessagePublisher::processRosImuMessage()
 
     if (sbg_imu_short_pub_)
     {
-      rclcpp::Duration eps = rclcpp::Duration::from_seconds(1e-8);
-      if ((sbg_ekf_quat_message_ == ekf_quat_message_zero) || ((rclcpp::Time(sbg_imu_short_message_.header.stamp) - rclcpp::Time(sbg_ekf_quat_message_.header.stamp)) < eps))
+      if ((sbg_ekf_quat_message_ == ekf_quat_message_zero) || areStampsClose(sbg_imu_short_message_.header.stamp, sbg_ekf_quat_message_.header.stamp))
       {
         imu_pub_->publish(message_wrapper_.createRosImuMessage(sbg_imu_short_message_, sbg_ekf_quat_message_));
       }
@@ -391,8 +399,7 @@ void MessagePublisher::processRosOdoMessage()
     {
       if (sbg_imu_short_pub_)
       {
-        rclcpp::Duration eps = rclcpp::Duration::from_seconds(1e-8);
-        if ((rclcpp::Time(sbg_imu_short_message_.header.stamp) - rclcpp::Time(sbg_ekf_nav_message_.header.stamp)) < eps)
+        if (areStampsClose(sbg_imu_short_message_.header.stamp, sbg_ekf_nav_message_.header.stamp))
         {
           /*
           * Odometry message can be generated from quaternion or euler angles.
@@ -400,14 +407,14 @@ void MessagePublisher::processRosOdoMessage()
           */
           if (sbg_ekf_quat_pub_)
           {
-            if ((rclcpp::Time(sbg_imu_short_message_.header.stamp) - rclcpp::Time(sbg_ekf_quat_message_.header.stamp)) < eps)
+            if (areStampsClose(sbg_imu_short_message_.header.stamp, sbg_ekf_quat_message_.header.stamp))
             {
               odometry_pub_->publish(message_wrapper_.createRosOdoMessage(sbg_imu_short_message_, sbg_ekf_nav_message_, sbg_ekf_quat_message_, sbg_ekf_euler_message_));
             }
           }
           else
           {
-            if ((rclcpp::Time(sbg_imu_short_message_.header.stamp) - rclcpp::Time(sbg_ekf_euler_message_.time_stamp)) < eps)
+            if (areStampsClose(sbg_imu_short_message_.header.stamp, sbg_ekf_euler_message_.header.stamp))
             {
               odometry_pub_->publish(message_wrapper_.createRosOdoMessage(sbg_imu_short_message_, sbg_ekf_nav_message_, sbg_ekf_euler_message_));
             }

--- a/src/message_publisher.cpp
+++ b/src/message_publisher.cpp
@@ -367,7 +367,7 @@ void MessagePublisher::processRosImuMessage()
 
     if (sbg_imu_short_pub_)
     {
-      if ((sbg_ekf_quat_message_ == ekf_quat_message_zero) || (sbg_imu_short_message_.time_stamp == sbg_ekf_quat_message_.time_stamp))
+      if (sbg_ekf_quat_pub_)
       {
         imu_pub_->publish(message_wrapper_.createRosImuMessage(sbg_imu_short_message_, sbg_ekf_quat_message_));
       }

--- a/src/message_wrapper.cpp
+++ b/src/message_wrapper.cpp
@@ -555,26 +555,13 @@ const sbg_driver::msg::SbgEkfVelBody MessageWrapper::createSbgEkfVelBodyMessage(
   ekf_vel_body_message.time_stamp        = ref_log_ekf_vel_body.timeStamp;
   ekf_vel_body_message.status            = createEkfStatusMessage(ref_log_ekf_vel_body.status);
 
-  if (use_enu_)
-  {
-    ekf_vel_body_message.velocity.x = ref_log_ekf_vel_body.velocity[1];
-    ekf_vel_body_message.velocity.y = ref_log_ekf_vel_body.velocity[0];
-    ekf_vel_body_message.velocity.z = -ref_log_ekf_vel_body.velocity[2];
+  ekf_vel_body_message.velocity.x = ref_log_ekf_vel_body.velocity[0];
+  ekf_vel_body_message.velocity.y = ref_log_ekf_vel_body.velocity[1];
+  ekf_vel_body_message.velocity.z = ref_log_ekf_vel_body.velocity[2];
 
-    ekf_vel_body_message.velocity_accuracy.x = ref_log_ekf_vel_body.velocityStdDev[1];
-    ekf_vel_body_message.velocity_accuracy.y = ref_log_ekf_vel_body.velocityStdDev[0];
-    ekf_vel_body_message.velocity_accuracy.z = ref_log_ekf_vel_body.velocityStdDev[2];
-  }
-  else
-  {
-    ekf_vel_body_message.velocity.x = ref_log_ekf_vel_body.velocity[0];
-    ekf_vel_body_message.velocity.y = ref_log_ekf_vel_body.velocity[1];
-    ekf_vel_body_message.velocity.z = ref_log_ekf_vel_body.velocity[2];
-
-    ekf_vel_body_message.velocity_accuracy.x = ref_log_ekf_vel_body.velocityStdDev[0];
-    ekf_vel_body_message.velocity_accuracy.y = ref_log_ekf_vel_body.velocityStdDev[1];
-    ekf_vel_body_message.velocity_accuracy.z = ref_log_ekf_vel_body.velocityStdDev[2];
-  }
+  ekf_vel_body_message.velocity_accuracy.x = ref_log_ekf_vel_body.velocityStdDev[0];
+  ekf_vel_body_message.velocity_accuracy.y = ref_log_ekf_vel_body.velocityStdDev[1];
+  ekf_vel_body_message.velocity_accuracy.z = ref_log_ekf_vel_body.velocityStdDev[2];
 
   return ekf_vel_body_message;
 }

--- a/src/message_wrapper.cpp
+++ b/src/message_wrapper.cpp
@@ -573,26 +573,14 @@ const sbg_driver::msg::SbgEkfRotAccel MessageWrapper::createSbgEkfRotAccelMessag
   ekf_vel_rot_accel_message.header            = createRosHeader(ref_log_ekf_rot_accel.timeStamp);
   ekf_vel_rot_accel_message.time_stamp        = ref_log_ekf_rot_accel.timeStamp;
 
-  if (use_enu_)
-  {
-    ekf_vel_rot_accel_message.rate.x = ref_log_ekf_rot_accel.rate[1];
-    ekf_vel_rot_accel_message.rate.y = ref_log_ekf_rot_accel.rate[0];
-    ekf_vel_rot_accel_message.rate.z = -ref_log_ekf_rot_accel.rate[2];
+  ekf_vel_rot_accel_message.rate.x = ref_log_ekf_rot_accel.rate[0];
+  ekf_vel_rot_accel_message.rate.y = ref_log_ekf_rot_accel.rate[1];
+  ekf_vel_rot_accel_message.rate.z = ref_log_ekf_rot_accel.rate[2];
 
-    ekf_vel_rot_accel_message.acceleration.x = ref_log_ekf_rot_accel.acceleration[1];
-    ekf_vel_rot_accel_message.acceleration.y = ref_log_ekf_rot_accel.acceleration[0];
-    ekf_vel_rot_accel_message.acceleration.z = -ref_log_ekf_rot_accel.acceleration[2];
-  }
-  else
-  {
-    ekf_vel_rot_accel_message.rate.x = ref_log_ekf_rot_accel.rate[0];
-    ekf_vel_rot_accel_message.rate.y = ref_log_ekf_rot_accel.rate[1];
-    ekf_vel_rot_accel_message.rate.z = ref_log_ekf_rot_accel.rate[2];
-
-    ekf_vel_rot_accel_message.acceleration.x = ref_log_ekf_rot_accel.acceleration[0];
-    ekf_vel_rot_accel_message.acceleration.y = ref_log_ekf_rot_accel.acceleration[1];
-    ekf_vel_rot_accel_message.acceleration.z = ref_log_ekf_rot_accel.acceleration[2];
-  }
+  ekf_vel_rot_accel_message.acceleration.x = ref_log_ekf_rot_accel.acceleration[0];
+  ekf_vel_rot_accel_message.acceleration.y = ref_log_ekf_rot_accel.acceleration[1];
+  ekf_vel_rot_accel_message.acceleration.z = ref_log_ekf_rot_accel.acceleration[2];
+  
 
   return ekf_vel_rot_accel_message;
 }

--- a/src/message_wrapper.cpp
+++ b/src/message_wrapper.cpp
@@ -1101,7 +1101,6 @@ const nav_msgs::msg::Odometry MessageWrapper::createRosOdoMessage(const sbg_driv
       pose.position.z = first_valid_altitude_;
 
       fillTransform(odom_init_frame_id_, odom_base_frame_id_, pose, transform);
-      tf_broadcaster_->sendTransform(transform);
       static_tf_broadcaster_->sendTransform(transform);
     }
   }
@@ -1207,7 +1206,6 @@ const nav_msgs::msg::Odometry MessageWrapper::createRosOdoMessage(const sbg_driv
       pose.position.z = first_valid_altitude_;
 
       fillTransform(odom_init_frame_id_, odom_frame_id_, pose, transform);
-      tf_broadcaster_->sendTransform(transform);
       static_tf_broadcaster_->sendTransform(transform);
     }
   }

--- a/src/message_wrapper.cpp
+++ b/src/message_wrapper.cpp
@@ -622,7 +622,6 @@ const sbg_driver::msg::SbgEkfRotAccel MessageWrapper::createSbgEkfRotAccelMessag
     ekf_vel_rot_accel_message.acceleration.z = ref_log_ekf_rot_accel.acceleration[2];
   }
 
-
   return ekf_vel_rot_accel_message;
 }
 

--- a/src/message_wrapper.cpp
+++ b/src/message_wrapper.cpp
@@ -621,7 +621,7 @@ const sbg_driver::msg::SbgEkfRotAccel MessageWrapper::createSbgEkfRotAccelMessag
     ekf_vel_rot_accel_message.acceleration.y = ref_log_ekf_rot_accel.acceleration[1];
     ekf_vel_rot_accel_message.acceleration.z = ref_log_ekf_rot_accel.acceleration[2];
   }
-  
+
 
   return ekf_vel_rot_accel_message;
 }


### PR DESCRIPTION
## Introduction
We have identified a few minor issues with our Ekinox Micro. First of all, we noticed that the body outputs are dependent on `use_enu`, which, in our opinion, does not make sense (see issue #66 ).

Furthermore, problems arose during the update when using the new `imu_short` message, which we have resolved with the appropriate changes.

We are open to feedback on the implementation or possible misunderstandings on our part.

## Summary
- ~Make body outputs (`/sbg/ekf_vel_body`, `/sbg/ekf_rot_accel_body`) independent of the `use_enu` flag (Closing #66)~
   - fixed through #80
- Enable publishing of ROS standard odom and imu message if `imu_data` ***OR*** `imu_short` is available
- Use `areStampsClose` to match `imu_short` message with other required inputs for imu/odom instead of hard comparison whether timestamp is the same (this was not the case with our Ekinox Micro)
- don't use a (dynamic) transform broadcaster for the static-tf `odom_init_frame_id_` --> `odom_frame_id_`

## Possible Open Todo's

The following tasks can be tackled after and based on your initial feedback, if this pull request is conceivable to be merged:

- Update the README
   - `/sbg/imu_short` is missing in published topics
   - Align section on [Body/Vehicle Frame](https://github.com/SBG-Systems/sbg_ros2_driver?tab=readme-ov-file#bodyvehicle-frame)
- Remove [magic-number in `areStampsClose`](https://github.com/ika-rwth-aachen/sbg_ros2_driver/blob/bcd96d0bd5aac9c5ef988387ece4cd9b80517fc4/src/message_publisher.cpp#L7)
- Switch back to `time_stamp` instead of `header.stamp` to match `imu_short` message with other required inputs for imu/odom