### PR TITLE
Add gps_frame_id parameter to fix GPS message frame ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,17 @@ frame_id: "imu_link_ned"
 > [!NOTE]
 > This parameter has not impact on the configuration and will be inserted as-is within the header field. The recommended default parameters for ros are imu_link when use_enu is activated, and imu_link_ned when use_enu is inactive. You can also use another frame_id as needed.
 
+### GPS Frame ID
+GPS position, velocity and true heading logs are expressed at the GNSS antenna phase center and not at the IMU.
+The frame_id of the header of these messages (including `sensor_msgs/NavSatFix`) can be set with this parameter:
+```
+# GPS antenna frame name
+gps_frame_id: "gps_link"
+```
+
+> [!NOTE]
+> If this parameter is not set, it defaults to frame_id to keep the previous driver behavior. Set it to the frame of your GNSS antenna so consumers such as robot_localization navsat_transform_node can correctly compensate the antenna lever arm.
+
 ### Frame convention
 The frame convention can be set to NED or ENU:
 * The NED convention is SBG Systems native convention so no transformation is applied

--- a/config/example/ellipse_A_default.yaml
+++ b/config/example/ellipse_A_default.yaml
@@ -269,6 +269,12 @@
       # Note: If the frame convention is NED so the default frame ID is (imu_link_ned)
       #       else if the convention is ENU so the default frame ID is (imu_link)
       frame_id: "imu_link_ned"
+
+      # GPS frame ID:
+      # Note: Frame of the GNSS antenna. GPS position, velocity and true heading
+      #       logs are expressed at the antenna phase center, not at the IMU.
+      #       If not set, it defaults to frame_id.
+      gps_frame_id: "gps_link"
     
       # Status general, clock, com aiding, solution, heave
       log_status: 8

--- a/config/example/ellipse_D_default.yaml
+++ b/config/example/ellipse_D_default.yaml
@@ -270,6 +270,12 @@
       #       else if the convention is ENU so the default frame ID is (imu_link)
       frame_id: "imu_link_ned"
 
+      # GPS frame ID:
+      # Note: Frame of the GNSS antenna. GPS position, velocity and true heading
+      #       logs are expressed at the antenna phase center, not at the IMU.
+      #       If not set, it defaults to frame_id.
+      gps_frame_id: "gps_link"
+
       # Status general, clock, com aiding, solution, heave
       log_status: 8
       # Includes IMU status, acc., gyro, temp delta speeds and delta angles values

--- a/config/example/ellipse_E_default.yaml
+++ b/config/example/ellipse_E_default.yaml
@@ -269,6 +269,12 @@
       # Note: If the frame convention is NED so the default frame ID is (imu_link_ned)
       #       else if the convention is ENU so the default frame ID is (imu_link)
       frame_id: "imu_link_ned"
+
+      # GPS frame ID:
+      # Note: Frame of the GNSS antenna. GPS position, velocity and true heading
+      #       logs are expressed at the antenna phase center, not at the IMU.
+      #       If not set, it defaults to frame_id.
+      gps_frame_id: "gps_link"
     
       # Status general, clock, com aiding, solution, heave
       log_status: 8

--- a/config/example/ellipse_N_default.yaml
+++ b/config/example/ellipse_N_default.yaml
@@ -270,6 +270,12 @@
       # Note: If the frame convention is NED so the default frame ID is (imu_link_ned)
       #       else if the convention is ENU so the default frame ID is (imu_link)
       frame_id: "imu_link_ned"
+
+      # GPS frame ID:
+      # Note: Frame of the GNSS antenna. GPS position, velocity and true heading
+      #       logs are expressed at the antenna phase center, not at the IMU.
+      #       If not set, it defaults to frame_id.
+      gps_frame_id: "gps_link"
     
       # Status general, clock, com aiding, solution, heave
       log_status: 8

--- a/config/sbg_device_file_default.yaml
+++ b/config/sbg_device_file_default.yaml
@@ -253,6 +253,12 @@
       # Note: If the frame convention is NED so the default frame ID is (imu_link_ned)
       #       else if the convention is ENU so the default frame ID is (imu_link)
       frame_id: "imu_link_ned"
+
+      # GPS frame ID:
+      # Note: Frame of the GNSS antenna. GPS position, velocity and true heading
+      #       logs are expressed at the antenna phase center, not at the IMU.
+      #       If not set, it defaults to frame_id.
+      gps_frame_id: "gps_link"
     
       # Status general, clock, com aiding, solution, heave
       log_status: 200

--- a/config/sbg_device_uart_default.yaml
+++ b/config/sbg_device_uart_default.yaml
@@ -269,6 +269,12 @@
       # Note: If the frame convention is NED so the default frame ID is (imu_link_ned)
       #       else if the convention is ENU so the default frame ID is (imu_link)
       frame_id: "imu_link_ned"
+
+      # GPS frame ID:
+      # Note: Frame of the GNSS antenna. GPS position, velocity and true heading
+      #       logs are expressed at the antenna phase center, not at the IMU.
+      #       If not set, it defaults to frame_id.
+      gps_frame_id: "gps_link"
     
       # Status general, clock, com aiding, solution, heave
       log_status: 200

--- a/config/sbg_device_udp_default.yaml
+++ b/config/sbg_device_udp_default.yaml
@@ -254,6 +254,12 @@
       # Note: If the frame convention is NED so the default frame ID is (imu_link_ned)
       #       else if the convention is ENU so the default frame ID is (imu_link)
       frame_id: "imu_link_ned"
+
+      # GPS frame ID:
+      # Note: Frame of the GNSS antenna. GPS position, velocity and true heading
+      #       logs are expressed at the antenna phase center, not at the IMU.
+      #       If not set, it defaults to frame_id.
+      gps_frame_id: "gps_link"
     
       # Status general, clock, com aiding, solution, heave
       log_status: 200

--- a/include/sbg_driver/config_store.h
+++ b/include/sbg_driver/config_store.h
@@ -117,6 +117,7 @@ private:
 
   uint32_t                    rate_frequency_;
   std::string                 frame_id_;
+  std::string                 gps_frame_id_;
   bool                        use_enu_;
 
   bool                        odom_enable_;
@@ -495,6 +496,13 @@ public:
    * \return                      Frame ID.
    */
   const std::string &getFrameId() const;
+
+  /*!
+   * Get the GPS frame ID (frame of the GNSS antenna).
+   *
+   * \return                      GPS antenna frame ID.
+   */
+  const std::string &getGpsFrameId() const;
 
   /*!
    * Get use ENU.

--- a/include/sbg_driver/message_wrapper.h
+++ b/include/sbg_driver/message_wrapper.h
@@ -92,6 +92,7 @@ private:
   sbg_driver::msg::SbgUtcTime  	      last_sbg_utc_;
   bool                                first_valid_utc_;
   std::string                         frame_id_;
+  std::string                         gps_frame_id_;
   bool                                use_enu_;
   TimeReference                       time_reference_;
 
@@ -285,6 +286,13 @@ public:
    * \param[in]  frame_id      Frame ID.
    */
   void setFrameId(const std::string &frame_id);
+
+  /*!
+   * Set the GPS frame ID (frame of the GNSS antenna).
+   *
+   * \param[in]  gps_frame_id  GPS antenna frame ID.
+   */
+  void setGpsFrameId(const std::string &gps_frame_id);
 
   /*!
    * Set use ENU.

--- a/src/config_store.cpp
+++ b/src/config_store.cpp
@@ -178,6 +178,10 @@ void ConfigStore::loadOutputFrameParameters(const rclcpp::Node& ref_node_handle)
   {
     ref_node_handle.get_parameter_or<std::string>("output.frame_id", frame_id_, "imu_link_ned");
   }
+
+  // GPS logs are expressed at the GNSS antenna phase center, not at the IMU.
+  // Fall back to frame_id to keep the previous behavior when unset.
+  ref_node_handle.get_parameter_or<std::string>("output.gps_frame_id", gps_frame_id_, frame_id_);
 }
 
 void ConfigStore::loadOutputTimeReference(const rclcpp::Node& ref_node_handle, const std::string& ref_key)
@@ -381,6 +385,11 @@ uint32_t ConfigStore::getReadingRateFrequency() const
 const std::string &ConfigStore::getFrameId() const
 {
   return frame_id_;
+}
+
+const std::string &ConfigStore::getGpsFrameId() const
+{
+  return gps_frame_id_;
 }
 
 bool ConfigStore::getUseEnu() const

--- a/src/message_publisher.cpp
+++ b/src/message_publisher.cpp
@@ -544,6 +544,7 @@ void MessagePublisher::initPublishers(rclcpp::Node& ref_ros_node_handle, const C
   message_wrapper_.setTimeReference(ref_config_store.getTimeReference());
 
   message_wrapper_.setFrameId(ref_config_store.getFrameId());
+  message_wrapper_.setGpsFrameId(ref_config_store.getGpsFrameId());
 
   message_wrapper_.setUseEnu(ref_config_store.getUseEnu());
 

--- a/src/message_wrapper.cpp
+++ b/src/message_wrapper.cpp
@@ -405,6 +405,11 @@ void MessageWrapper::setFrameId(const std::string &frame_id)
   frame_id_ = frame_id;
 }
 
+void MessageWrapper::setGpsFrameId(const std::string &gps_frame_id)
+{
+  gps_frame_id_ = gps_frame_id;
+}
+
 void MessageWrapper::setUseEnu(bool enu)
 {
   use_enu_ = enu;
@@ -636,6 +641,7 @@ const sbg_driver::msg::SbgGpsHdt MessageWrapper::createSbgGpsHdtMessage(const Sb
   sbg_driver::msg::SbgGpsHdt gps_hdt_message;
 
   gps_hdt_message.header           = createRosHeader(ref_log_gps_hdt.timeStamp);
+  gps_hdt_message.header.frame_id  = gps_frame_id_;
   gps_hdt_message.time_stamp       = ref_log_gps_hdt.timeStamp;
   gps_hdt_message.status           = ref_log_gps_hdt.status;
   gps_hdt_message.tow              = ref_log_gps_hdt.timeOfWeek;
@@ -663,8 +669,9 @@ const sbg_driver::msg::SbgGpsPos MessageWrapper::createSbgGpsPosMessage(const Sb
 {
   sbg_driver::msg::SbgGpsPos gps_pos_message;
 
-  gps_pos_message.header      = createRosHeader(ref_log_gps_pos.timeStamp);
-  gps_pos_message.time_stamp  = ref_log_gps_pos.timeStamp;
+  gps_pos_message.header          = createRosHeader(ref_log_gps_pos.timeStamp);
+  gps_pos_message.header.frame_id = gps_frame_id_;
+  gps_pos_message.time_stamp      = ref_log_gps_pos.timeStamp;
 
   gps_pos_message.status              = createGpsPosStatusMessage(ref_log_gps_pos);
   gps_pos_message.gps_tow             = ref_log_gps_pos.timeOfWeek;
@@ -707,8 +714,9 @@ const sbg_driver::msg::SbgGpsVel MessageWrapper::createSbgGpsVelMessage(const Sb
 {
   sbg_driver::msg::SbgGpsVel gps_vel_message;
 
-  gps_vel_message.header      = createRosHeader(ref_log_gps_vel.timeStamp);
-  gps_vel_message.time_stamp  = ref_log_gps_vel.timeStamp;
+  gps_vel_message.header          = createRosHeader(ref_log_gps_vel.timeStamp);
+  gps_vel_message.header.frame_id = gps_frame_id_;
+  gps_vel_message.time_stamp      = ref_log_gps_vel.timeStamp;
   gps_vel_message.status      = createGpsVelStatusMessage(ref_log_gps_vel);
   gps_vel_message.gps_tow     = ref_log_gps_vel.timeOfWeek;
   gps_vel_message.course_acc  = ref_log_gps_vel.courseAcc;
@@ -1421,7 +1429,8 @@ const sensor_msgs::msg::NavSatFix MessageWrapper::createRosNavSatFixMessage(cons
 {
   sensor_msgs::msg::NavSatFix nav_sat_fix_message;
 
-  nav_sat_fix_message.header = createRosHeader(ref_sbg_gps_msg.time_stamp);
+  nav_sat_fix_message.header          = createRosHeader(ref_sbg_gps_msg.time_stamp);
+  nav_sat_fix_message.header.frame_id = ref_sbg_gps_msg.header.frame_id;
 
   if (ref_sbg_gps_msg.status.type == SBG_ECOM_GNSS_POS_TYPE_NO_SOLUTION)
   {


### PR DESCRIPTION
GNSS logs (GPS#_POS/VEL/HDT) are expressed at the antenna phase center, not at the IMU. Publish the SbgGpsPos, SbgGpsVel, SbgGpsHdt and NavSatFix headers with a new dedicated output.gps_frame_id parameter instead of the IMU frame_id, as required by the sensor_msgs/NavSatFix specification, so consumers such as navsat_transform_node apply the correct antenna lever arm.

The parameter falls back to output.frame_id when unset to keep the previous behavior for existing configurations.

Fixes #54