### PR TITLE
Fix wrapAnglePi returning out-of-range or reflected angles

### DIFF
--- a/src/sbg_ros_helpers.cpp
+++ b/src/sbg_ros_helpers.cpp
@@ -9,17 +9,14 @@
 
 float sbg::helpers::wrapAnglePi(float angle_rad)
 {
-  if (angle_rad > SBG_PI_F)
+  float wrapped_angle_rad = fmodf(angle_rad + SBG_PI_F, SBG_PI_F * 2.0f);
+
+  if (wrapped_angle_rad < 0.0f)
   {
-    return (SBG_PI_F * 2.0f - fmodf(angle_rad, SBG_PI_F * 2.0f));
+    wrapped_angle_rad += SBG_PI_F * 2.0f;
   }
 
-  if (angle_rad < -SBG_PI_F)
-  {
-    return (SBG_PI_F * 2.0f + fmodf(angle_rad, SBG_PI_F * 2.0f));
-  }
-
-  return angle_rad;
+  return wrapped_angle_rad - SBG_PI_F;
 }
 
 float sbg::helpers::wrapAngle360(float angle_deg)


### PR DESCRIPTION
The previous implementation reflected angles instead of wrapping them (e.g. +3pi/2 returned +pi/2 instead of -pi/2) and returned values up to +2pi for inputs at or beyond +/-2pi, violating the documented [-Pi ; Pi] range. Use the canonical modulo-shift wrap ((angle + pi) mod 2pi) - pi instead.

The only call site (ENU yaw conversion) operates on [-3pi/2, pi/2] where both implementations agree, so published data is unchanged.

Fixes #64