### PR TITLE
Fix body frame convention comments in IMU and Mag messages

### DIFF
--- a/msg/SbgImuData.msg
+++ b/msg/SbgImuData.msg
@@ -9,27 +9,27 @@ SbgImuStatus imu_status
 
 # Filtered Accelerometer [m/s^2]
 #
-# NED convention:
+# SBG body frame convention (FRD - Forward-Right-Down), when use_enu is false:
 #   x: X axis of the device frame
 #   y: Y axis of the device frame
 #   z: Z axis of the device frame
 #
-# ENU convention:
-#   x: Y axis of the device frame
-#   y: X axis of the device frame
+# ROS body frame convention (FLU - Forward-Left-Up, per REP-103), when use_enu is true:
+#   x: X axis of the device frame
+#   y: -Y axis of the device frame
 #   z: -Z axis of the device frame
 geometry_msgs/Vector3 accel
 
 # Filtered Gyroscope [rad/s]
 #
-# NED convention:
+# SBG body frame convention (FRD - Forward-Right-Down), when use_enu is false:
 #   x: X axis of the device frame
 #   y: Y axis of the device frame
 #   z: Z axis of the device frame
 #
-# ENU convention:
-#   x: Y axis of the device frame
-#   y: X axis of the device frame
+# ROS body frame convention (FLU - Forward-Left-Up, per REP-103), when use_enu is true:
+#   x: X axis of the device frame
+#   y: -Y axis of the device frame
 #   z: -Z axis of the device frame
 geometry_msgs/Vector3 gyro
 
@@ -38,26 +38,26 @@ float32 temp
 
 # Sculling output [m/s2]
 #
-# NED convention:
+# SBG body frame convention (FRD - Forward-Right-Down), when use_enu is false:
 #   x: X axis of the device frame
 #   y: Y axis of the device frame
 #   z: Z axis of the device frame
 #
-# ENU convention:
-#   x: Y axis of the device frame
-#   y: X axis of the device frame
+# ROS body frame convention (FLU - Forward-Left-Up, per REP-103), when use_enu is true:
+#   x: X axis of the device frame
+#   y: -Y axis of the device frame
 #   z: -Z axis of the device frame
 geometry_msgs/Vector3 delta_vel
 
 # Coning output [rad/s]
 #
-# NED convention:
+# SBG body frame convention (FRD - Forward-Right-Down), when use_enu is false:
 #   x: X axis of the device frame
 #   y: Y axis of the device frame
 #   z: Z axis of the device frame
 #
-# ENU convention:
-#   x: Y axis of the device frame
-#   y: X axis of the device frame
+# ROS body frame convention (FLU - Forward-Left-Up, per REP-103), when use_enu is true:
+#   x: X axis of the device frame
+#   y: -Y axis of the device frame
 #   z: -Z axis of the device frame
 geometry_msgs/Vector3 delta_angle

--- a/msg/SbgImuShort.msg
+++ b/msg/SbgImuShort.msg
@@ -9,27 +9,27 @@ SbgImuStatus imu_status
 
 # X, Y, Z delta velocity. Unit is 1048576 LSB for 1 m.s^-2.
 #
-# NED convention:
+# SBG body frame convention (FRD - Forward-Right-Down), when use_enu is false:
 #   x: X axis of the device frame
 #   y: Y axis of the device frame
 #   z: Z axis of the device frame
 #
-# ENU convention:
-#   x: Y axis of the device frame
-#   y: X axis of the device frame
+# ROS body frame convention (FLU - Forward-Left-Up, per REP-103), when use_enu is true:
+#   x: X axis of the device frame
+#   y: -Y axis of the device frame
 #   z: -Z axis of the device frame
 geometry_msgs/Vector3 delta_velocity
 
 # X, Y, Z delta angle. Unit is 67108864 LSB for 1 rad.s^-1.
 #
-# NED convention:
+# SBG body frame convention (FRD - Forward-Right-Down), when use_enu is false:
 #   x: X axis of the device frame
 #   y: Y axis of the device frame
 #   z: Z axis of the device frame
 #
-# ENU convention:
-#   x: Y axis of the device frame
-#   y: X axis of the device frame
+# ROS body frame convention (FLU - Forward-Left-Up, per REP-103), when use_enu is true:
+#   x: X axis of the device frame
+#   y: -Y axis of the device frame
 #   z: -Z axis of the device frame
 geometry_msgs/Vector3 delta_angle
 

--- a/msg/SbgMag.msg
+++ b/msg/SbgMag.msg
@@ -6,27 +6,27 @@ uint32 time_stamp
 
 # Magnetometer output
 #
-# NED convention:
+# SBG body frame convention (FRD - Forward-Right-Down), when use_enu is false:
 #   x: X axis of the device frame
 #   y: Y axis of the device frame
 #   z: Z axis of the device frame
 #
-# ENU convention:
-#   x: Y axis of the device frame
-#   y: X axis of the device frame
+# ROS body frame convention (FLU - Forward-Left-Up, per REP-103), when use_enu is true:
+#   x: X axis of the device frame
+#   y: -Y axis of the device frame
 #   z: -Z axis of the device frame
 geometry_msgs/Vector3 mag
 
 # Accelerometer output  [m/s^2]
 #
-# NED convention:
+# SBG body frame convention (FRD - Forward-Right-Down), when use_enu is false:
 #   x: X axis of the device frame
 #   y: Y axis of the device frame
 #   z: Z axis of the device frame
 #
-# ENU convention:
-#   x: Y axis of the device frame
-#   y: X axis of the device frame
+# ROS body frame convention (FLU - Forward-Left-Up, per REP-103), when use_enu is true:
+#   x: X axis of the device frame
+#   y: -Y axis of the device frame
 #   z: -Z axis of the device frame
 geometry_msgs/Vector3 accel
 


### PR DESCRIPTION
The ENU-mode comments in SbgImuData.msg, SbgImuShort.msg and SbgMag.msg documented a navigation-frame axis swap [Y, X, -Z] while the code correctly converts body-frame data from FRD to FLU [X, -Y, -Z] per REP-103. Relabel both blocks as FRD/FLU body frame conventions and document the actual mapping. Comments only, no behavior change.

Fixes #65