### PR TITLE
Fix use_enu handling of body-frame EKF outputs

### DIFF
--- a/include/sbg_driver/message_wrapper.h
+++ b/include/sbg_driver/message_wrapper.h
@@ -376,9 +376,10 @@ public:
    * Create a SBG-ROS Ekf Rotation Acceleration message.
    *
    * \param[in] ref_log_ekf_rot_accel       SBG Ekf Rotation Acceleration log.
+   * \param[in] body_frame                  True if the log is expressed in the body frame, false for the navigation frame.
    * \return                                Ekf Rotation Acceleration message.
    */
-  const sbg_driver::msg::SbgEkfRotAccel createSbgEkfRotAccelMessage(const SbgEComLogEkfRotAccel& ref_log_ekf_rot_accel) const;
+  const sbg_driver::msg::SbgEkfRotAccel createSbgEkfRotAccelMessage(const SbgEComLogEkfRotAccel& ref_log_ekf_rot_accel, bool body_frame) const;
 
   /*!
    * Create a SBG-ROS event message.

--- a/msg/SbgEkfRotAccel.msg
+++ b/msg/SbgEkfRotAccel.msg
@@ -5,23 +5,47 @@ std_msgs/Header header
 uint32 time_stamp
 
 # INS rotation rate free from earth rotation and sensor bias/scale errors (rad.s^-1)
-# In NED convention:
-#   X: North
-#   Y: East
-#   Z: Down
-# In ENU convention:
-#   X: East
-#   Y: North
-#   Z: Up
+#
+# On the sbg/ekf_rot_accel_body topic, expressed in the body frame:
+#   FRD (Forward-Right-Down), when use_enu is false:
+#     x: X axis of the device frame
+#     y: Y axis of the device frame
+#     z: Z axis of the device frame
+#   FLU (Forward-Left-Up, per REP-103), when use_enu is true:
+#     x: X axis of the device frame
+#     y: -Y axis of the device frame
+#     z: -Z axis of the device frame
+#
+# On the sbg/ekf_rot_accel_ned topic, expressed in the navigation frame:
+#   NED, when use_enu is false:
+#     x: North
+#     y: East
+#     z: Down
+#   ENU, when use_enu is true:
+#     x: East
+#     y: North
+#     z: Up
 geometry_msgs/Vector3 rate
 
 # INS accelerations and free from gravity and sensor bias/scale errors (m.s^-2)
-# In NED convention:
-#   X: North
-#   Y: East
-#   Z: Down
-# In ENU convention:
-#   X: East
-#   Y: North
-#   Z: Up
+#
+# On the sbg/ekf_rot_accel_body topic, expressed in the body frame:
+#   FRD (Forward-Right-Down), when use_enu is false:
+#     x: X axis of the device frame
+#     y: Y axis of the device frame
+#     z: Z axis of the device frame
+#   FLU (Forward-Left-Up, per REP-103), when use_enu is true:
+#     x: X axis of the device frame
+#     y: -Y axis of the device frame
+#     z: -Z axis of the device frame
+#
+# On the sbg/ekf_rot_accel_ned topic, expressed in the navigation frame:
+#   NED, when use_enu is false:
+#     x: North
+#     y: East
+#     z: Down
+#   ENU, when use_enu is true:
+#     x: East
+#     y: North
+#     z: Up
 geometry_msgs/Vector3 acceleration

--- a/msg/SbgEkfVelBody.msg
+++ b/msg/SbgEkfVelBody.msg
@@ -6,25 +6,20 @@ std_msgs/Header header
 uint32 time_stamp
 
 # Velocity [m/s]
-# In NED convention:
-#   x: North
-#   y: East
-#   z: Down
-# In ENU convention:
-#   x: East
-#   y: North
-#   z: Up
+#
+# SBG body frame convention (FRD - Forward-Right-Down), when use_enu is false:
+#   x: X axis of the device frame
+#   y: Y axis of the device frame
+#   z: Z axis of the device frame
+#
+# ROS body frame convention (FLU - Forward-Left-Up, per REP-103), when use_enu is true:
+#   x: X axis of the device frame
+#   y: -Y axis of the device frame
+#   z: -Z axis of the device frame
 geometry_msgs/Vector3 velocity
 
 # Velocity accuracy (1 sigma) [m/s].
-# In NED convention:
-#   x: North
-#   y: East
-#   z: Vertical
-# In ENU convention:
-#   x: East
-#   y: North
-#   z: Vertical
+# Standard deviation along each body axis (x, y, z), identical in FRD and FLU conventions.
 geometry_msgs/Vector3 velocity_accuracy
 
 #  Global solution status

--- a/src/message_publisher.cpp
+++ b/src/message_publisher.cpp
@@ -647,14 +647,14 @@ void MessagePublisher::publish(SbgEComClass sbg_msg_class, SbgEComMsgId sbg_msg_
       case SBG_ECOM_LOG_EKF_ROT_ACCEL_BODY:
         if (sbg_ekf_rot_accel_body_pub_)
         {
-          sbg_ekf_rot_accel_body_pub_->publish(message_wrapper_.createSbgEkfRotAccelMessage(ref_sbg_log.ekfRotAccel));
+          sbg_ekf_rot_accel_body_pub_->publish(message_wrapper_.createSbgEkfRotAccelMessage(ref_sbg_log.ekfRotAccel, true));
         }
         break;
 
       case SBG_ECOM_LOG_EKF_ROT_ACCEL_NED:
         if (sbg_ekf_rot_accel_ned_pub_)
         {
-          sbg_ekf_rot_accel_ned_pub_->publish(message_wrapper_.createSbgEkfRotAccelMessage(ref_sbg_log.ekfRotAccel));
+          sbg_ekf_rot_accel_ned_pub_->publish(message_wrapper_.createSbgEkfRotAccelMessage(ref_sbg_log.ekfRotAccel, false));
         }
         break;
 

--- a/src/message_wrapper.cpp
+++ b/src/message_wrapper.cpp
@@ -562,12 +562,12 @@ const sbg_driver::msg::SbgEkfVelBody MessageWrapper::createSbgEkfVelBodyMessage(
 
   if (use_enu_)
   {
-    ekf_vel_body_message.velocity.x = ref_log_ekf_vel_body.velocity[1];
-    ekf_vel_body_message.velocity.y = ref_log_ekf_vel_body.velocity[0];
+    ekf_vel_body_message.velocity.x = ref_log_ekf_vel_body.velocity[0];
+    ekf_vel_body_message.velocity.y = -ref_log_ekf_vel_body.velocity[1];
     ekf_vel_body_message.velocity.z = -ref_log_ekf_vel_body.velocity[2];
 
-    ekf_vel_body_message.velocity_accuracy.x = ref_log_ekf_vel_body.velocityStdDev[1];
-    ekf_vel_body_message.velocity_accuracy.y = ref_log_ekf_vel_body.velocityStdDev[0];
+    ekf_vel_body_message.velocity_accuracy.x = ref_log_ekf_vel_body.velocityStdDev[0];
+    ekf_vel_body_message.velocity_accuracy.y = ref_log_ekf_vel_body.velocityStdDev[1];
     ekf_vel_body_message.velocity_accuracy.z = ref_log_ekf_vel_body.velocityStdDev[2];
   }
   else
@@ -584,14 +584,24 @@ const sbg_driver::msg::SbgEkfVelBody MessageWrapper::createSbgEkfVelBodyMessage(
   return ekf_vel_body_message;
 }
 
-const sbg_driver::msg::SbgEkfRotAccel MessageWrapper::createSbgEkfRotAccelMessage(const SbgEComLogEkfRotAccel& ref_log_ekf_rot_accel) const
+const sbg_driver::msg::SbgEkfRotAccel MessageWrapper::createSbgEkfRotAccelMessage(const SbgEComLogEkfRotAccel& ref_log_ekf_rot_accel, bool body_frame) const
 {
   sbg_driver::msg::SbgEkfRotAccel ekf_vel_rot_accel_message;
 
   ekf_vel_rot_accel_message.header            = createRosHeader(ref_log_ekf_rot_accel.timeStamp);
   ekf_vel_rot_accel_message.time_stamp        = ref_log_ekf_rot_accel.timeStamp;
 
-  if (use_enu_)
+  if (use_enu_ && body_frame)
+  {
+    ekf_vel_rot_accel_message.rate.x = ref_log_ekf_rot_accel.rate[0];
+    ekf_vel_rot_accel_message.rate.y = -ref_log_ekf_rot_accel.rate[1];
+    ekf_vel_rot_accel_message.rate.z = -ref_log_ekf_rot_accel.rate[2];
+
+    ekf_vel_rot_accel_message.acceleration.x = ref_log_ekf_rot_accel.acceleration[0];
+    ekf_vel_rot_accel_message.acceleration.y = -ref_log_ekf_rot_accel.acceleration[1];
+    ekf_vel_rot_accel_message.acceleration.z = -ref_log_ekf_rot_accel.acceleration[2];
+  }
+  else if (use_enu_)
   {
     ekf_vel_rot_accel_message.rate.x = ref_log_ekf_rot_accel.rate[1];
     ekf_vel_rot_accel_message.rate.y = ref_log_ekf_rot_accel.rate[0];


### PR DESCRIPTION
The EKF body velocity and body rotation rate / acceleration messages were converted with the navigation-frame NED to ENU axis swap [Y, X, -Z] when use_enu is true, although these logs are expressed in the body frame. Apply the FRD to FLU body-frame conversion [X, -Y, -Z] (REP-103) instead, consistent with the IMU and magnetometer messages, and keep velocity standard deviations in X, Y, Z order.

The SbgEkfRotAccel message is shared between the body and NED logs, so createSbgEkfRotAccelMessage now takes the frame as a parameter; the NED variant behavior is unchanged. Message comments are updated to describe the actual conventions.

Data published on sbg/ekf_vel_body and sbg/ekf_rot_accel_body with use_enu enabled changes with this fix.

Fixes #66