### PR TITLE
Document GNSS antenna and INS reference points in messages

### DIFF
--- a/msg/SbgEkfNav.msg
+++ b/msg/SbgEkfNav.msg
@@ -27,6 +27,10 @@ geometry_msgs/Vector3 velocity
 #   z: Vertical
 geometry_msgs/Vector3 velocity_accuracy
 
+# The position is the EKF fused solution expressed at the INS reference point,
+# compensated for the configured lever arms (unlike the raw GNSS position from
+# the SbgGpsPos message, which is expressed at the antenna phase center).
+
 # Latitude [degrees]. Positive is north of equator; negative is south
 float64 latitude
 

--- a/msg/SbgGpsHdt.msg
+++ b/msg/SbgGpsHdt.msg
@@ -18,6 +18,7 @@ uint16 status
 uint32 tow
 
 # True heading angle (0 to 360 deg)
+# The heading is defined by the baseline from the main to the auxiliary GNSS antenna.
 # NED convention: Rotation about the down axis. Zero when the X axis is pointing North.
 # ENU convention: Rotation about the up axis. Zero when the X axis is pointing East. (opposite sign compared to NED)
 float32 true_heading

--- a/msg/SbgGpsPos.msg
+++ b/msg/SbgGpsPos.msg
@@ -10,6 +10,12 @@ SbgGpsPosStatus status
 # GPS Time of Week ms
 uint32 gps_tow
 
+# The position is the raw GNSS solution expressed at the main antenna phase
+# center of the corresponding GNSS receiver. It is NOT compensated for the
+# antenna lever arm (see the gps_frame_id parameter).
+# For the EKF fused position expressed at the INS reference point, use the
+# SbgEkfNav message instead.
+
 # Latitude [degrees]; Positive is north of equator; negative is south
 float64 latitude
 

--- a/msg/SbgGpsVel.msg
+++ b/msg/SbgGpsVel.msg
@@ -11,6 +11,8 @@ SbgGpsVelStatus status
 uint32 gps_tow
 
 # Velocity [m/s]
+# The velocity is the raw GNSS solution measured at the main antenna phase
+# center of the corresponding GNSS receiver.
 # In NED convention:
 #   X: North
 #   Y: East


### PR DESCRIPTION
Clarify in SbgGpsPos, SbgGpsVel, SbgGpsHdt and SbgEkfNav that raw GNSS position and velocity are expressed at the main antenna phase center, that the dual antenna heading is defined by the main to auxiliary antenna baseline, and that the EKF navigation solution is expressed at the INS reference point.

Fixes #70