### PR TITLE
Enable MSVC math constants

### DIFF
--- a/src/message_wrapper.cpp
+++ b/src/message_wrapper.cpp
@@ -1,3 +1,5 @@
+#define _USE_MATH_DEFINES
+
 // File header
 #include "message_wrapper.h"
 
@@ -12,7 +14,12 @@
 #include <sbg_ros_helpers.h>
 
 // STL headers
+#include <cmath>
 #include <type_traits>
+
+#ifndef M_SQRT2
+#define M_SQRT2 1.41421356237309504880
+#endif
 
 using sbg::MessageWrapper;
 

--- a/src/sbg_utm.cpp
+++ b/src/sbg_utm.cpp
@@ -1,3 +1,5 @@
+#define _USE_MATH_DEFINES
+
 // File header
 #include "sbg_utm.h"
 


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: patch/ros-rolling-sbg-driver.win.patch, authored by Daisuke Nishimatsu.

Best-guess rationale: sbg_driver uses non-standard math constants such as M_PI and M_SQRT2. MSVC exposes the common constants only when _USE_MATH_DEFINES is set before including cmath, and M_SQRT2 is not consistently provided, so adding the define and a local fallback keeps the current calculations portable.