### PR TITLE
Use std::this_thread::sleep_for in log replay

### DIFF
--- a/src/sbg_device.cpp
+++ b/src/sbg_device.cpp
@@ -5,6 +5,8 @@
 #include <iomanip>
 #include <fstream>
 #include <ctime>
+#include <chrono>
+#include <thread>
 
 // SbgECom headers
 #include <version/sbgVersion.h>
@@ -118,7 +120,7 @@ void SbgDevice::onLogReceived(SbgEComClass msg_class, SbgEComMsgId msg, const Sb
       log_replay_last_timestamp_ = timestamp;
     }
 
-    usleep(time_to_sleep);
+    std::this_thread::sleep_for(std::chrono::microseconds(time_to_sleep));
   }
 
   //


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: `patch/ros-rolling-sbg-driver.patch`, authored by Tobias Fischer.

The log replay delay currently uses `usleep()`, which is POSIX-specific. Replacing it with `std::this_thread::sleep_for(std::chrono::microseconds(...))` preserves the existing microsecond delay behavior while keeping the source portable to non-POSIX toolchains.
